### PR TITLE
Get the slab password from the keychain

### DIFF
--- a/src/python/slab/main.py
+++ b/src/python/slab/main.py
@@ -49,6 +49,8 @@ def main(args=None):
 	k = slab.slablib.SQLKeychain(path)
 	password=os.getenv("SLAB_PASSWORD", None)
 	if not password:
+		password = subprocess.check_output(['/usr/bin/security','find-generic-password','-a','slab','-w'],universal_newlines=True).rstrip()
+	if not password:
 		pwpath = os.getenv("SLAB_PWPATH","~/.config/.slab_password")
 		pwpath = os.path.expanduser(pwpath)
 		if os.path.exists(pwpath):

--- a/src/python/slab/main.py
+++ b/src/python/slab/main.py
@@ -34,10 +34,15 @@ def choice(choices):
 	name = fd.name
 	#print("fname:%s" % name)
 	fd.close()
-	out = subprocess.check_output(['/usr/bin/osascript',name],universal_newlines=True)
-	#str(out).strip().replace('\n','')
-	out = out.rstrip()
-	#print("out:%s" % out)
+
+	try:
+		out = subprocess.check_output(['/usr/bin/osascript',name],universal_newlines=True)
+		#str(out).strip().replace('\n','')
+		out = out.rstrip()
+		#print("out:%s" % out)
+	except:
+		sys.exit()
+
 	os.unlink(name)
 	return out
 

--- a/src/python/slab/main.py
+++ b/src/python/slab/main.py
@@ -63,12 +63,17 @@ def main(args=None):
 	k.unlock(password, filter='sudolikeaboss')
 	#pprint.pprint(k.items)
 	choices=[]
-	for i in k.items:
-		choices.append(i['title'])
-	#print("choices:%s" % pprint.pformat(choices))
-	#c = ''
-	# use applescript to get a choice.
-	c = choice(choices)
+	if len(k.items) == 1:
+		c = k.items[0]['title']
+	else:
+		for i in k.items:
+			choices.append(i['title'])
+		#print("choices:%s" % pprint.pformat(choices))
+		#c = ''
+		# use applescript to get a choice.
+		c = choice(choices)
+		print(">>",c)
+
 	# go through all the sudolikeaboss items and print the password when match found.
 	for i in k.items:
 		if i['title'] == c:


### PR DESCRIPTION
Grab the `slab` password from the MacOS keychain, and auto-select the account if a single `sudolikeaboss://` entry is present in the database.