### PR TITLE
Deal with fields not having a designation

### DIFF
--- a/src/python/slab/main.py
+++ b/src/python/slab/main.py
@@ -173,7 +173,7 @@ def main(args=None):
         if i['title'] == c:
             #pprint.pprint(k.item(i['id']))
             for f in k.item(i['id'])['details']['fields']:
-                if f['designation'] == 'password':
+                if 'designation' in f and f['designation'] == 'password':
                     print(f['value'])
                     sys.stdout.flush()
 


### PR DESCRIPTION
Some records in my 1Password setup don't have a "designation" value in every field.  For example:
```
{'id': 'signup-submit;opid=__5', 'name': '', 'type': 'I', 'value': 'Sign up'}
```

This change skips any fields without a designation, rather than crashing out with a KeyError.